### PR TITLE
Fix upstream doc change, clarification

### DIFF
--- a/YetiREST/README.md
+++ b/YetiREST/README.md
@@ -5,6 +5,10 @@ apiPath =  __CRM_URL__/webservice/RestApi/
 ```
 ## Configuration file
 
+ * apiPath must end with an `__CRM_URL__/webservice/`.
+ * For CRM versions greater than 6.1.255, you need to add: RestApi , Portal. `__CRM_URL__/webservice/RestApi/`.
+ * For CRM versions greater than 6.3, you need to add: WebserviceStandard , WebservicePremium. `__CRM_URL__/webservice/RestApi/`.
+ 
 ```php
 return [
 	'apiPath' => 'https://gitdeveloper.yetiforce.com/webservice/RestApi/',

--- a/YetiREST/config.php
+++ b/YetiREST/config.php
@@ -1,8 +1,9 @@
 <?php
 /**
  * Configuration file.
- * wsApiKey must end with an `__CRM_URL__/webservice/`.
+ * apiPath must end with an `__CRM_URL__/webservice/`.
  * For CRM versions greater than 6.1.255, you need to add: RestApi , Portal. `__CRM_URL__/webservice/RestApi/`.
+ * For CRM versions greater than 6.3, you need to add: WebserviceStandard , WebservicePremium. `__CRM_URL__/webservice/RestApi/`.
  *
  * @copyright YetiForce Sp. z o.o
  * @author    Mariusz Krzaczkowski <m.krzaczkowski@yetiforce.com>


### PR DESCRIPTION
Hello, 

This fix mistake that wsApiKey is apiPath. 
Add 6.3 change
add apiPath version warning directly into the README
